### PR TITLE
iOS WireGuard VPN Connection Fix

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>pro.tark.wireguardExampleApp.app_group_id</key>
+	<string>group.pro.tark.wireguardExampleApp</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/ios/Shared/FileManager+Extension.swift
+++ b/ios/Shared/FileManager+Extension.swift
@@ -10,7 +10,7 @@ extension FileManager {
   static var appGroupId: String? {
     #if os(iOS)
     //let appGroupIdInfoDictionaryKey = "com.wireguard.ios.app_group_id"
-    let appGroupIdInfoDictionaryKey = "pro.tark.wireguardExampleApp"
+    let appGroupIdInfoDictionaryKey = "pro.tark.wireguardExampleApp.app_group_id"
     #elseif os(macOS)
     let appGroupIdInfoDictionaryKey = "com.wireguard.macos.app_group_id"
     #else


### PR DESCRIPTION
This PR provides the following:
1) Adds the necessary key/value pair in Runner/Info.plist: pro.tark.wireguardExampleApp.app_group_id -> group.pro.tark.wireguardExampleApp
2) Modifies the FileManager.appGroupId static method to look for this key in Runner/Info.plist.
3) Uses retry logic which reloads the VPN profile from preferences after receiving NEVPNErrorDomain Code=1 (Configuration Invalid) then successfully connects the VPN tunnel.

**Explanation**
When the WireGuardKit extension instantiates the `NETunnelProviderProtocol` it attempts to create a `passwordReference` variable with a call to `Keychain.makeReference`. Inside of this method, it attempts to set `items[kSecAttrAccessGroup] = FileManager.appGroupId`. `FileManager.appGroupId` is obtained by looking up the app’s bundle Info.plist file for a specific key in this case `pro.tark.wireguardExampleApp` which I have changed to `pro.tark.wireguardExampleApp.app_group_id` to make it clearer. Adding this key into Info.plist with a value of `group.pro.tark.wireguardExampleApp` and using the retry logic will enable the VPN connection to successfully connect.